### PR TITLE
Revert change to heuristic to order children

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -50,7 +50,8 @@ void orderChildren(Node *parent) {
         if(wonBoard(parent->child[iter]->board)) {
             values[iter] = INT_MAX;
         } else {
-            values[iter] = getHeuristic(parent->child[iter], next(parent->turn));
+            values[iter] = matches(parent->child[iter]->board, match3);
+            // values[iter] = getHeuristic(parent->child[iter], next(parent->turn));
         }
     }
 


### PR DESCRIPTION
See 2218be6b3a87c7b08c2e1bef1ca758550b0d20b6

The change in that commit is kept as a comment, as depending on the
situation one might be more convenient than the other. In particular:

 - If the heuristic is simpleHeuristic, ordering by number of match3 is
   more efficient
 - Otherwise, it is probably wiser to order them by their heuristic