### PR TITLE
Improve indexing in transposition table

### DIFF
--- a/src/table.c
+++ b/src/table.c
@@ -1,6 +1,10 @@
 #include "table.h"
 
-unsigned getIndex(const Table *table, const Key key) {
+unsigned getIndex(const Table *table, Key key) {
+    Key mirrored = mirrorKey(key);
+    if(mirrored > key) {
+        key = mirrored;
+    }
     return key % table->size;
 }
 


### PR DESCRIPTION
We want to identify mirrored positions.

By convention, we only keep the mirrored version of a table that is
bigger as an integer, considering its bitboard representation. This
helps us identify mirrored positions at a low cost.