### PR TITLE
Remove unnecessary width specifier on `printSMask`

### DIFF
--- a/src/masks.c
+++ b/src/masks.c
@@ -1640,7 +1640,7 @@ static const size_t nmasks[] = {
 };
 
 static void printSMask(const SMask mask) {
-    printf("\t{ .main = (Mask) 0x%16.16zX, .anti = (Mask) 0x%16.16zX },\n", mask.main, mask.anti);
+    printf("\t{ .main = (Mask) 0x%.16zX, .anti = (Mask) 0x%.16zX },\n", mask.main, mask.anti);
 }
 
 static void initMasks(void) {


### PR DESCRIPTION
Close #30